### PR TITLE
Fix : correct dimension mapping in Mask2Former custom parser

### DIFF
--- a/post_processor/nvdsinfer_custombboxparser_tao.cpp
+++ b/post_processor/nvdsinfer_custombboxparser_tao.cpp
@@ -429,8 +429,8 @@ bool NvDsInferParseCustomMask2Former (std::vector<NvDsInferLayerInfo> const &out
     const NvDsInferLayerInfo *pred_scores = layerFinder("pred_scores");
     const unsigned int det_max_instances = pred_masks->inferDims.d[0];
 
-    int width = pred_masks->inferDims.d[1];
-    int height = pred_masks->inferDims.d[2];
+    int width = pred_masks->inferDims.d[2];
+    int height = pred_masks->inferDims.d[1];
     int* pclass = (int*)pred_classes->buffer;
     float* pmask = (float*)pred_masks->buffer;
     float* pscore = (float*)pred_scores->buffer;


### PR DESCRIPTION
Issue : Masks appear as scrambled horizontal lines in below picture instead of properly shaped object overlays.
![out - frame at 0m4s](https://github.com/user-attachments/assets/5188107e-4ce8-4fff-963b-7e14b1794924)

Fixed the scrambled line artifacts in the mask output by swapping the width and height dimension assignments in the custom parser code. The result after edit shown below.
![fix - frame at 0m3s](https://github.com/user-attachments/assets/d85a5d2c-917d-4ed7-9d66-c097b097c808)
